### PR TITLE
iGPU Spoofed to HD 6000 (#17)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,12 @@
+### Update 08/29/2020
+- Spoofed iGPU to HD 6000 as default
+  - Required for some devices but has no negative effects on devices that do not require it
+- Mentioned Intel wifi kext in readme
+  - Won't be supported here but is worth a mention and should work fine.
+
 ### Update 08/15/2020
 - Switch back to VoodooI2CSynaptics.kext
   - No more VoodooRMI.kext
-
 
 ### Update 08/09/2020
 - Confirmed working on MacOS 11.0 Big Sur Public Beta

--- a/config-base.plist
+++ b/config-base.plist
@@ -226,7 +226,9 @@
 			<key>PciRoot(0x0)/Pci(0x2,0x0)</key>
 			<dict>
 				<key>AAPL,ig-platform-id</key>
-				<data>AgAWFg==</data>
+				<data>BgAmFg==</data>
+				<key>device-id</key>
+				<data>JhYAAA==</data>
 			</dict>
 		</dict>
 		<key>Delete</key>

--- a/readme.md
+++ b/readme.md
@@ -11,32 +11,11 @@
 
 
 #
-### Update 08/13/2020
-- Switch back to VoodooI2CSynaptics.kext
-  - No more VoodooRMI.kext
-
-### Update 08/09/2020
-- Confirmed working on MacOS 11.0 Big Sur Public Beta
-- Config updated
-  - No longer maintaining multiple configs
-- VoodooPS2Controller.kext updated
-  - Most top row keys are now mapped through the kext
-  - Keyboard backlight now controlled with left ctrl + alt + "comma" and "period" keys
-  - Karabiner no longer required!
-- Some clean up/restructuring of readme.md
-
-### Update 08/05/2020
-- Switched to SSDT-KBBL.aml for keyboard backlight control
-  - DSDT.aml no longer required
-
-### Update 08/04/2020
-- Updated configs for OpenCore 0.6.0
-- Switched to [VoodooRMI](https://github.com/VoodooSMBus/VoodooRMI/releases) as the trackpad kext
-  - No longer using a modified VoodooI2CSynaptics.kext
-- In an attempt to make this easier to maintain, this will be the last time multiple configs are supplied
-   
-### Update 07/29/2020
-- Confirmed working on 10.15.6. I updated successfully through System Preferences.
+### Update 08/28/2020
+- Spoofed iGPU to HD 6000 as default
+  - Required for some devices but has no negative effects on devices that do not require it
+- Mentioned Intel wifi kext in readme
+  - Won't be supported here but is worth a mention and should work fine.
 
 #
 
@@ -49,6 +28,8 @@
   - A [compatible m.2 WiFi card](https://dortania.github.io/Wireless-Buyers-Guide/types-of-wireless-card/m2.html#supported-cards)
     - I can confirm the Dell DW1560 works in MacOS (with additional kexts), Windows, & Ubuntu
     - Other users have reported success with the BCM94360NG (has native MacOS support so no additional kexts required!)
+    - **Note:** There is now an Intel wifi kext and the stock wireless card is listed as compatible. I don't have experience with using this so it won't be covered here.
+      - https://github.com/OpenIntelWireless/itlwm
   - MacOS installer flash drive 
     - See the guides linked in [Basic Installation Steps](https://github.com/TheRandMan/Hackintosh---Dell-Chromebook-13-7310#basic-installation-steps) below
 
@@ -69,7 +50,7 @@
   - Just about everything!
   
 ### What's Not Working: 
-  - Touchscreen - unlikely that this will ever work - fairly uncommon to have one on this device anyway
+  - Touchscreen - unlikely that this will ever work as there is no kext for it - fairly uncommon to have one on this device anyway
   - Most DRM does not work. This means no Apple TV shows, Hulu, Netflix (in Safari), Amazon Prime streaming, etc.
       - This isn't specific to the Dell CB13. DRM simply does not work on an iGPU only Hackintosh 
   
@@ -122,9 +103,6 @@ most of the files in this repo were created using this guide so you won't need t
 Place config.plist in /EFI/OC/
   - [config-base.plist](https://github.com/TheRandMan/Hackintosh---Dell-Chromebook-13-7310/tree/master/config-base.plist)
     - Use [ProperTree](https://github.com/corpnewt/ProperTree) to make the following edits to the config-base.plist file
-    - Some i3 models require the iGPU to be spoofed to HD 6000. If you have trouble booting MacOS you may need to add the boxed lines seen [here](https://github.com/TheRandMan/Hackintosh---Dell-Chromebook-13-7310/blob/master/Images/HD%206000%20spoofing.png) - Fix found by @mankot14
-      - AAPL,ig-platform-id - Data - 06002616
-      - device-id - Data - 26160000
     - If you are using a BCM94360NG for wifi:
       - Delete the following kext entries from the config:
         - AirportBrcmFixup.kext


### PR DESCRIPTION
iGPU spoofed to HD 6000 by default in config-base.plist. It was previously thought this was only required for some i3 models but it also applies to some i5 models. It doesn't seem to have any negative effects on devices that do not require it so it's safe to add as a default.

Mentioned new Intel wifi kext in readme. It won't be covered here but is definitely worth a mention.